### PR TITLE
Combine README.md and docs site

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ node_modules/
 .vscode/
 demo/
 lait-docs-site/
+docs-generator/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
+<!-- WARNING: File is auto-generated. Edit docs-generator/docs.md instead -->
 # lait; an AWK-inspired TypeScript Command-Line Utility
+
+[_GitHub_](https://github.com/ajbowen249/lait),
+[_NPM_](https://www.npmjs.com/package/@ajbowen249/lait)
 
 > Check out the interactive version of these docs [here](https://ajbowen249.github.io/lait/)!
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ajbowen249/lait",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@ajbowen249/lait",
-            "version": "0.1.4",
+            "version": "0.1.5",
             "license": "MIT",
             "workspaces": [
                 "packages/*"
@@ -13986,7 +13986,7 @@
         "docs-generator": {
             "version": "file:packages/docs-generator",
             "requires": {
-                "markdown-it": "*"
+                "markdown-it": "^13.0.1"
             }
         },
         "doctrine": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2910,8 +2910,7 @@
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
         "node_modules/array-differ": {
             "version": "3.0.0",
@@ -4015,6 +4014,10 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/docs-generator": {
+            "resolved": "packages/docs-generator",
+            "link": true
         },
         "node_modules/doctrine": {
             "version": "3.0.0",
@@ -6613,6 +6616,14 @@
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "dev": true
         },
+        "node_modules/linkify-it": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+            "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+            "dependencies": {
+                "uc.micro": "^1.0.1"
+            }
+        },
         "node_modules/load-json-file": {
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-6.2.0.tgz",
@@ -6788,6 +6799,37 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/markdown-it": {
+            "version": "13.0.1",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
+            "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
+            "dependencies": {
+                "argparse": "^2.0.1",
+                "entities": "~3.0.1",
+                "linkify-it": "^4.0.1",
+                "mdurl": "^1.0.1",
+                "uc.micro": "^1.0.5"
+            },
+            "bin": {
+                "markdown-it": "bin/markdown-it.js"
+            }
+        },
+        "node_modules/markdown-it/node_modules/entities": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+            "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/mdurl": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+            "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
         },
         "node_modules/memorystream": {
             "version": "0.3.1",
@@ -10070,6 +10112,11 @@
                 "node": ">=4.2.0"
             }
         },
+        "node_modules/uc.micro": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+            "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
+        },
         "node_modules/uglify-js": {
             "version": "3.17.4",
             "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
@@ -10843,6 +10890,13 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/docs-generator": {
+            "version": "1.0.0",
+            "license": "ISC",
+            "dependencies": {
+                "markdown-it": "^13.0.1"
             }
         },
         "packages/lait-core": {
@@ -13076,8 +13130,7 @@
         "argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
         "array-differ": {
             "version": "3.0.0",
@@ -13928,6 +13981,12 @@
             "dev": true,
             "requires": {
                 "path-type": "^4.0.0"
+            }
+        },
+        "docs-generator": {
+            "version": "file:packages/docs-generator",
+            "requires": {
+                "markdown-it": "*"
             }
         },
         "doctrine": {
@@ -15914,6 +15973,14 @@
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "dev": true
         },
+        "linkify-it": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+            "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+            "requires": {
+                "uc.micro": "^1.0.1"
+            }
+        },
         "load-json-file": {
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-6.2.0.tgz",
@@ -16051,6 +16118,30 @@
             "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
             "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
             "dev": true
+        },
+        "markdown-it": {
+            "version": "13.0.1",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
+            "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
+            "requires": {
+                "argparse": "^2.0.1",
+                "entities": "~3.0.1",
+                "linkify-it": "^4.0.1",
+                "mdurl": "^1.0.1",
+                "uc.micro": "^1.0.5"
+            },
+            "dependencies": {
+                "entities": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+                    "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
+                }
+            }
+        },
+        "mdurl": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+            "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
         },
         "memorystream": {
             "version": "0.3.1",
@@ -18492,6 +18583,11 @@
             "version": "4.9.4",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
             "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg=="
+        },
+        "uc.micro": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+            "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
         },
         "uglify-js": {
             "version": "3.17.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ajbowen249/lait",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "license": "MIT",
     "bin": {
         "lait": "./packages/lait-core/dist/index.js"

--- a/packages/docs-generator/docs.md
+++ b/packages/docs-generator/docs.md
@@ -1,0 +1,201 @@
+<!-- This file specifies the docs for both the main README.md and the HTML docs site. -->
+<!-- #targets md,html -->
+# lait; an AWK-inspired TypeScript Command-Line Utility
+
+<!-- #targets md -->
+> Check out the interactive version of these docs [here](https://ajbowen249.github.io/lait/)!
+<!-- #targets md,html -->
+
+`lait` is a command-line utility designed as an alternative to `awk`. Like `awk`, `lait` matches input line-by-line
+against a list of regular expressions and runs the first block of code it matches. Unlike `awk`, `lait` uses
+`TypeScript` as its scripting language.
+
+```shell
+$ cat demo_input
+OrderId Item Quantity
+#a2fr5 Socks 16
+#d8j38 Avocado 2
+#8fh39 Shampoo 1
+#qb6ag Candle 3
+$ lait '/#\w{5} \w+ \d+/; { print($[2], $[1]) }' demo_input
+16 Socks
+2 Avocado
+1 Shampoo
+3 Candle
+```
+<!-- #targets html -->
+Here is an interactive version of that example. Both the input "file" and script are editable. Give it a try!
+TODO: Playground
+<!-- #targets md,html -->
+
+A `lait` program is just a `TypeScript` script. However, `lait` picks it apart and puts it into a wrapper program, where
+top-level blocks preceded by a regular expression literal are registered as handlers for matching lines of input. A top-
+level block not preceded by a regex will be registered as the default handler if given. Any statements written before
+the first handler will be run before scanning input, and all code after the first handler definition will be run after
+processing input. Note that this means there is no need for an explicit `BEGIN` or `END` block like in `awk`.
+
+Let's take a look at a more complicated `lait` script. Like `awk`, `lait` can take a file as its script input:
+
+```typescript
+interface Order {
+    id: string;
+    item: string;
+    quantity: number;
+}
+
+const letterOrders: Order[] = [];
+const digitOrders: Order[] = [];
+
+function parseOrder($: string[]) {
+    return {
+        id: $[0],
+        item: $[1],
+        quantity: parseInt($[2]),
+    };
+}
+
+/[a-z]\w{4} \w+ \d+/; {
+    letterOrders.push(parseOrder($));
+}
+
+/\d\w{4} \w+ \d+/; {
+    digitOrders.push(parseOrder($));
+}
+
+function toTable(order: Order) {
+    return `${order.id}: ${order.quantity} ${order.item}`;
+}
+
+// Note: print is just an alias of console.log
+print('Order ID starts with letter:');
+print(letterOrders.map(toTable).join('\n'));
+
+print('Order ID starts with digit:');
+print(digitOrders.map(toTable).join('\n'));
+```
+
+```shell
+$ lait -f demo.lait.ts demo_input
+Order ID starts with letter:
+#a2fr5: 16 Socks
+#d8j38: 2 Avocado
+#qb6ag: 3 Candle
+Order ID starts with digit:
+#8fh39: 1 Shampoo
+```
+
+Note that programs of this size are less common. Like `awk`, `lait` programs are meant to be small and integrated into
+shell operations.
+
+The first input given to handlers is `$`, the array of "fields" on the line. Unlike `awk`, the array is simply a zero-
+based array of fields, and there is not a "complete line" entry in `$`. Like `awk`, the default field separator is
+space, and it can be overridden via the `FS` global:
+
+```shell
+$ cat demo.csv
+Name,Age,ID
+Carol,25,2lf8ah
+Bob,21,j8efy3g
+Jesse,34,j8fhiuad8
+
+$ lait 'FS=`,`; { print($[0], `#${$[2]}`); }' demo.csv
+Name #ID
+Carol #2lf8ah
+Bob #j8efy3g
+Jesse #j8fhiuad8
+```
+
+In addition to `$`, the handlers are also given `m`, the `RegExpMatchArray` from when it was compared to the regex, as
+well as `g`, the (possibly undefined) set of capture groups, aka `m.groups`:
+
+```shell
+lait '/(?<id>#\w{5}) (?<name>\w+) (?<amnt>\d+)/; { print(g.amnt, g.name, m[0]) }' demo_input
+16 Socks #a2fr5 Socks 16
+2 Avocado #d8j38 Avocado 2
+1 Shampoo #8fh39 Shampoo 1
+3 Candle #qb6ag Candle 3
+```
+
+`lait` can also accept input from standard in:
+
+```shell
+$ ls -al
+total 14
+drwxr-xr-x 1 user 197609   0 Dec  8 22:01 .
+drwxr-xr-x 1 user 197609   0 Dec  8 21:47 ..
+-rw-r--r-- 1 user 197609  61 Dec  8 19:19 demo.csv
+-rw-r--r-- 1 user 197609 699 Dec  8 22:01 demo.lait.ts
+-rw-r--r-- 1 user 197609  87 Dec  8 18:46 demo_input
+
+$ ls -al | lait '/^d|-/;{print($[8], `(${$[4]} bytes)`)}'
+. (0 bytes)
+.. (0 bytes)
+demo.csv (61 bytes)
+demo.lait.ts (699 bytes)
+demo_input (87 bytes)
+```
+
+## Globals
+
+In addition to `FS`, there is also `TRIM_EMPTY`, which is `true` by default as is usually convenient for processing
+space-aligned data like in the `ls` example. That's less useful when processing CSVs:
+
+```shell
+$ cat demo2.csv
+Name,Favorite Film (Optional),Score
+Cathy Smith,A Fistful of Dollars,78
+Paulo Henry MacMasterson III,Finding Nemo,4
+Bob Nofunpants,,4
+
+$ lait 'FS=`,`;TRIM_EMPTY=false; { print($[0], $[1] || `does not like movies :(`)  }' demo2.csv
+Name Favorite Film (Optional)
+Cathy Smith A Fistful of Dollars
+Paulo Henry MacMasterson III Finding Nemo
+Bob Nofunpants does not like movies :(
+```
+
+Without `TRIM_EMPTY=false;`, the last line of that would have been:
+```shell
+Bob Nofunpants 4
+```
+
+## Imports
+
+<!-- #targets md -->
+You can import from the Node standard library, as well as any node modules you would expect to be accessible either
+globally or from a module installed in the working directory's `node_modules`.
+
+```shell
+$ lait 'import * as _ from "lodash"; print(_.isNumber(12));'
+true
+```
+
+> *Note:* Imports from local files are not yet working
+
+<!-- #targets html -->
+ You can import from the Node standard library, as well as any node modules you would expect to be accessible either globally or from a module installed in the working directory's `node_modules`. Note: This doesn't work in the interactive playground since it is run by the browser. Also note that imports from local files are not yet working.
+
+```shell
+$ lait 'import * as _ from "lodash"; print(_.isNumber(12));'
+true
+```
+<!-- #targets md,html -->
+## Installation
+
+All you gotta do is
+
+```shell
+npm i -g @ajbowen249/lait
+```
+
+## But Why?
+
+While `awk` is a very powerful tool, it can have a few rough edges. Those being:
+
+1. Fragmentation - One must always be wary of which implementation they're using, and which builtins are available.
+2. Regex Syntax - `awk` has yet another regular expression syntax to remember, and it even varies by vendor.
+3. Scripting Syntax - Like the regex point, `awk` using its own scripting language means one must play the, "is _this_
+   how I do x in this language?" game. While `TypeScript` (and, let's be real, using the type system here will be rare)
+   is certainly not universal, it's much more likely someone willing to install an `NPM` package will be familiar with
+   it. Standard `awk` is also light on language features and built-ins, and having built-in array sort and higher-order
+   functions should prove useful in problems typically solved with `awk`.

--- a/packages/docs-generator/docs.md
+++ b/packages/docs-generator/docs.md
@@ -2,6 +2,9 @@
 <!-- #targets md,html -->
 # lait; an AWK-inspired TypeScript Command-Line Utility
 
+[_GitHub_](https://github.com/ajbowen249/lait),
+[_NPM_](https://www.npmjs.com/package/@ajbowen249/lait)
+
 <!-- #targets md -->
 > Check out the interactive version of these docs [here](https://ajbowen249.github.io/lait/)!
 <!-- #targets md,html -->
@@ -25,7 +28,21 @@ $ lait '/#\w{5} \w+ \d+/; { print($[2], $[1]) }' demo_input
 ```
 <!-- #targets html -->
 Here is an interactive version of that example. Both the input "file" and script are editable. Give it a try!
-TODO: Playground
+
+```none
+<!-- #playground-input 0 -->
+OrderId Item Quantity
+#a2fr5 Socks 16
+#d8j38 Avocado 2
+#8fh39 Shampoo 1
+#qb6ag Candle 3
+```
+
+```typescript
+<!-- #playground-script 0 -->
+/#\w{5} \w+ \d+/; { print($[2], $[1]) }
+```
+
 <!-- #targets md,html -->
 
 A `lait` program is just a `TypeScript` script. However, `lait` picks it apart and puts it into a wrapper program, where
@@ -35,8 +52,23 @@ the first handler will be run before scanning input, and all code after the firs
 processing input. Note that this means there is no need for an explicit `BEGIN` or `END` block like in `awk`.
 
 Let's take a look at a more complicated `lait` script. Like `awk`, `lait` can take a file as its script input:
+<!-- #targets html -->
+```shell
+$lait -f demo.lait.ts demo_input
+```
+
+```none
+<!-- #playground-input 1 -->
+OrderId Item Quantity
+#a2fr5 Socks 16
+#d8j38 Avocado 2
+#8fh39 Shampoo 1
+#qb6ag Candle 3
+```
+<!-- #targets md,html -->
 
 ```typescript
+<!-- #playground-script 1 -->
 interface Order {
     id: string;
     item: string;
@@ -74,6 +106,7 @@ print('Order ID starts with digit:');
 print(digitOrders.map(toTable).join('\n'));
 ```
 
+<!-- #targets md -->
 ```shell
 $ lait -f demo.lait.ts demo_input
 Order ID starts with letter:
@@ -83,6 +116,7 @@ Order ID starts with letter:
 Order ID starts with digit:
 #8fh39: 1 Shampoo
 ```
+<!-- #targets md,html -->
 
 Note that programs of this size are less common. Like `awk`, `lait` programs are meant to be small and integrated into
 shell operations.
@@ -91,6 +125,20 @@ The first input given to handlers is `$`, the array of "fields" on the line. Unl
 based array of fields, and there is not a "complete line" entry in `$`. Like `awk`, the default field separator is
 space, and it can be overridden via the `FS` global:
 
+<!-- #targets html-->
+```shell
+<!-- #playground-input 2 -->
+Name,Age,ID
+Carol,25,2lf8ah
+Bob,21,j8efy3g
+Jesse,34,j8fhiuad8
+```
+
+```typescript
+<!-- #playground-script 2 -->
+FS=`,`; { print($[0], `#${$[2]}`); }
+```
+<!-- #targets md-->
 ```shell
 $ cat demo.csv
 Name,Age,ID
@@ -104,10 +152,26 @@ Carol #2lf8ah
 Bob #j8efy3g
 Jesse #j8fhiuad8
 ```
+<!-- #targets md,html-->
 
 In addition to `$`, the handlers are also given `m`, the `RegExpMatchArray` from when it was compared to the regex, as
 well as `g`, the (possibly undefined) set of capture groups, aka `m.groups`:
 
+<!-- #targets html-->
+```shell
+<!-- #playground-input 3 -->
+OrderId Item Quantity
+#a2fr5 Socks 16
+#d8j38 Avocado 2
+#8fh39 Shampoo 1
+#qb6ag Candle 3
+```
+
+```typescript
+<!-- #playground-script 3 -->
+/(?<id>#\w{5}) (?<name>\w+) (?<amnt>\d+)/; { print(g.amnt, g.name, m[0]) }
+```
+<!-- #targets md-->
 ```shell
 lait '/(?<id>#\w{5}) (?<name>\w+) (?<amnt>\d+)/; { print(g.amnt, g.name, m[0]) }' demo_input
 16 Socks #a2fr5 Socks 16
@@ -115,6 +179,7 @@ lait '/(?<id>#\w{5}) (?<name>\w+) (?<amnt>\d+)/; { print(g.amnt, g.name, m[0]) }
 1 Shampoo #8fh39 Shampoo 1
 3 Candle #qb6ag Candle 3
 ```
+<!-- #targets md,html-->
 
 `lait` can also accept input from standard in:
 
@@ -140,6 +205,20 @@ demo_input (87 bytes)
 In addition to `FS`, there is also `TRIM_EMPTY`, which is `true` by default as is usually convenient for processing
 space-aligned data like in the `ls` example. That's less useful when processing CSVs:
 
+<!-- #targets html-->
+```shell
+<!-- #playground-input 4 -->
+Name,Favorite Film (Optional),Score
+Cathy Smith,A Fistful of Dollars,78
+Paulo Henry MacMasterson III,Finding Nemo,4
+Bob Nofunpants,,4
+```
+
+```typescript
+<!-- #playground-script 4 -->
+FS=`,`;TRIM_EMPTY=false; { print($[0], $[1] || `does not like movies :(`)  }
+```
+<!-- #targets md-->
 ```shell
 $ cat demo2.csv
 Name,Favorite Film (Optional),Score
@@ -153,6 +232,7 @@ Cathy Smith A Fistful of Dollars
 Paulo Henry MacMasterson III Finding Nemo
 Bob Nofunpants does not like movies :(
 ```
+<!-- #targets md,html-->
 
 Without `TRIM_EMPTY=false;`, the last line of that would have been:
 ```shell

--- a/packages/docs-generator/index.js
+++ b/packages/docs-generator/index.js
@@ -1,4 +1,8 @@
 const fs = require('fs/promises');
+const MarkdownIt = require('markdown-it');
+
+const playgroundTagRegex = /<!-- +#playground-(?<type>script|input) +(?<index>\d+) +-->/g;
+const htmlCodeSegmentRegex = /<pre>\s*<code class=".*?">\s*(?<content>.*?)\s*<\/code>\s*<\/pre>/gs;
 
 async function main() {
     const file = (await fs.readFile([__dirname, 'docs.md'].join('/'))).toString();
@@ -18,7 +22,6 @@ async function main() {
             switch (left) {
                 case '#targets':
                     activeTargets = right.split(',');
-                    console.log(activeTargets)
                     continue;
                 default:
                     break;
@@ -29,6 +32,77 @@ async function main() {
             targets[target].push(line);
         }
     }
+
+    const readmeFile = '<!-- WARNING: File is auto-generated. Edit docs-generator/docs.md instead -->\n' +
+        targets.md
+        // We don't yank these lines in the initial parse so we can find them later
+        .filter(x => !x.match(playgroundTagRegex))
+        .join('\n')
+    await fs.writeFile([__dirname, '..', '..', 'README.md'].join('/'), readmeFile);
+
+    const inputFiles = [];
+    const scripts = [];
+
+    const htmlMD = targets.html.join('\n');
+    const md = new MarkdownIt({
+        highlight: (str, lang, attrs) => {
+            let content = str;
+            const maybeMatch = playgroundTagRegex.exec(content);
+            if (maybeMatch) {
+                content = content
+                    .replace(playgroundTagRegex, '')
+                    .replace(/\\/g, '\\\\')
+                    .replace(/`/g, '\\`')
+                    .replace(/\$/g, '\\$')
+                    .trim();
+                const isScript = maybeMatch.groups.type === 'script';
+                const index = maybeMatch.groups.index;
+                (isScript ? scripts : inputFiles).push(content);
+                return isScript ? `<LaitPlayground
+    :default-script-input="scriptInput${index}"
+    :default-file-input="fileInput${index}"
+/><br />` : '<div />';
+            }
+
+            return '';
+        },
+    });
+
+    let htmlTemplate = md.render(htmlMD);
+    // IMPROVE: There's got to be a way to keep md from outputting it this way in the first place...
+    htmlTemplate = htmlTemplate.replace(htmlCodeSegmentRegex, (substr, ...args) => {
+        if (args.length >= 3) {
+            const innerContent = args[3].content;
+            if (innerContent === '<div />') {
+                return '';
+            } else if (innerContent.startsWith('<LaitPlayground')) {
+                return innerContent;
+            }
+        }
+
+        return substr;
+    });
+
+    // now put it into Vue
+    const vue = `<!-- WARNING: This file is auto-generated -->
+<template>
+    <main>
+${htmlTemplate.split('\n').join('\n')}
+    </main>
+</template>
+<script setup lang="ts">
+
+import LaitPlayground from '@/components/LaitPlayground.vue';
+import { ref } from 'vue';
+
+${inputFiles.map((x, i) => `const fileInput${i} = ref(\`${x}\`);`).join('\n')}
+
+${scripts.map((x, i) => `const scriptInput${i} = ref(\`${x}\`);`).join('\n')}
+
+</script>
+`;
+
+    await fs.writeFile([__dirname, '..', 'lait-docs-site', 'src', 'views', 'HomeView.vue'].join('/'), vue);
 }
 
 main();

--- a/packages/docs-generator/index.js
+++ b/packages/docs-generator/index.js
@@ -1,0 +1,34 @@
+const fs = require('fs/promises');
+
+async function main() {
+    const file = (await fs.readFile([__dirname, 'docs.md'].join('/'))).toString();
+    const lines = file.split('\n');
+
+    const targets = {
+        md: [],
+        html: [],
+    };
+
+    let activeTargets = [];
+
+    for (const line of lines) {
+        if (line.startsWith('<!-- #')) {
+            const command = line.replace('<!--', '').replace('-->', '').trim();
+            const [left, right] = command.split(' ');
+            switch (left) {
+                case '#targets':
+                    activeTargets = right.split(',');
+                    console.log(activeTargets)
+                    continue;
+                default:
+                    break;
+            }
+        }
+
+        for (const target of activeTargets) {
+            targets[target].push(line);
+        }
+    }
+}
+
+main();

--- a/packages/docs-generator/package.json
+++ b/packages/docs-generator/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "docs-generator",
+  "version": "1.0.0",
+  "description": "Generates both the main README and the html docs",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "generate": "node index.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "markdown-it": "^13.0.1"
+  }
+}

--- a/packages/lait-docs-site/src/assets/base.css
+++ b/packages/lait-docs-site/src/assets/base.css
@@ -50,7 +50,7 @@
   font-weight: normal;
 }
 
-.code-span {
+code {
   font-family: monospace;
   color: var(--color-purple-mute);
 }
@@ -86,13 +86,14 @@ label {
   line-height: 2.5rem;
 }
 
-textarea {
+textarea, pre {
   background-color: var(--color-mocha-dark);
   color: var(--color-white-mute);
   border: 1px solid var(--color-white-mute);
   border-radius: 8px;
   height: auto;
   width: 100%;
+  padding: 15px;
 }
 
 a {

--- a/packages/lait-docs-site/src/components/LaitPlayground.vue
+++ b/packages/lait-docs-site/src/components/LaitPlayground.vue
@@ -30,7 +30,7 @@
     <button @click="run">Run</button>
     <button @click="() => consoleOutput = ''">Clear</button>
     <br />
-    <textarea v-model="consoleOutput" id="output" cols="80" rows="10" disabled /><br />
+    <pre><code class="language-shell">{{ consoleOutput }}</code></pre>
 </template>
 
 <script setup lang="ts">

--- a/packages/lait-docs-site/src/views/HomeView.vue
+++ b/packages/lait-docs-site/src/views/HomeView.vue
@@ -1,89 +1,62 @@
+<!-- WARNING: This file is auto-generated -->
 <template>
     <main>
-        <h1>lait; an AWK-inspired TypeScript Command-Line Utility</h1>
-
-        <i><a href="https://github.com/ajbowen249/lait">GitHub</a></i>,
-        <i><a href="https://www.npmjs.com/package/@ajbowen249/lait">NPM</a></i>
-
-        <p>
-            <span class="code-span">lait</span> is a command-line utility designed as an alternative to <span class="code-span">awk</span>. Like
-            <span class="code-span">awk</span>, <span class="code-span">lait</span> matches input line-by-line against a list of regular expressions and runs
-            the first block of code it matches. Unlike <span class="code-span">awk</span>, <span class="code-span">lait</span> uses <span class="code-span">
-            TypeScript</span> as its scripting language.
-        </p><br />
-        <textarea cols="80" rows="12" disabled>
-$ cat demo_input
+<h1>lait; an AWK-inspired TypeScript Command-Line Utility</h1>
+<p><a href="https://github.com/ajbowen249/lait"><em>GitHub</em></a>,
+<a href="https://www.npmjs.com/package/@ajbowen249/lait"><em>NPM</em></a></p>
+<p><code>lait</code> is a command-line utility designed as an alternative to <code>awk</code>. Like <code>awk</code>, <code>lait</code> matches input line-by-line
+against a list of regular expressions and runs the first block of code it matches. Unlike <code>awk</code>, <code>lait</code> uses
+<code>TypeScript</code> as its scripting language.</p>
+<pre><code class="language-shell">$ cat demo_input
 OrderId Item Quantity
 #a2fr5 Socks 16
 #d8j38 Avocado 2
 #8fh39 Shampoo 1
 #qb6ag Candle 3
-$ lait '/#\\w{5} \\w+ \\d+/; { print($[2], $[1]) }' demo_input
+$ lait '/#\w{5} \w+ \d+/; { print($[2], $[1]) }' demo_input
 16 Socks
 2 Avocado
 1 Shampoo
 3 Candle
-        </textarea><br /><br />
+</code></pre>
+<p>Here is an interactive version of that example. Both the input &quot;file&quot; and script are editable. Give it a try!</p>
 
-        <h2>Interactive Example</h2>
-        <p>
-            Here is an interactive version of that example. Both the input "file" and script are editable. Give it a try!
-        </p>
+<LaitPlayground
+    :default-script-input="scriptInput0"
+    :default-file-input="fileInput0"
+/><br />
+<p>A <code>lait</code> program is just a <code>TypeScript</code> script. However, <code>lait</code> picks it apart and puts it into a wrapper program, where
+top-level blocks preceded by a regular expression literal are registered as handlers for matching lines of input. A top-
+level block not preceded by a regex will be registered as the default handler if given. Any statements written before
+the first handler will be run before scanning input, and all code after the first handler definition will be run after
+processing input. Note that this means there is no need for an explicit <code>BEGIN</code> or <code>END</code> block like in <code>awk</code>.</p>
+<p>Let's take a look at a more complicated <code>lait</code> script. Like <code>awk</code>, <code>lait</code> can take a file as its script input:</p>
+<pre><code class="language-shell">$lait -f demo.lait.ts demo_input
+</code></pre>
 
-        <LaitPlayground
-            :default-script-input="scriptInput1"
-            :default-file-input="fileInput1"
-        /><br />
+<LaitPlayground
+    :default-script-input="scriptInput1"
+    :default-file-input="fileInput1"
+/><br />
+<p>Note that programs of this size are less common. Like <code>awk</code>, <code>lait</code> programs are meant to be small and integrated into
+shell operations.</p>
+<p>The first input given to handlers is <code>$</code>, the array of &quot;fields&quot; on the line. Unlike <code>awk</code>, the array is simply a zero-
+based array of fields, and there is not a &quot;complete line&quot; entry in <code>$</code>. Like <code>awk</code>, the default field separator is
+space, and it can be overridden via the <code>FS</code> global:</p>
 
-        <p>
-            A <span class="code-span">lait</span> program is just a <span class="code-span">TypeScript</span> script. However, <span class="code-span">lait
-            </span> picks it apart and puts it into a wrapper program, where top-level blocks preceded by a regular expression literal are registered as
-            handlers for matching lines of input. A top-level block not preceded by a regex will be registered as the default handler if given. Any statements
-            written before the first handler will be run before scanning input, and all code after the first handler definition will be run after processing
-            input. Note that this means there is no need for an explicit <span class="code-span">BEGIN</span> or <span class="code-span">END</span> block like
-            in <span class="code-span">awk</span>.<br />
+<LaitPlayground
+    :default-script-input="scriptInput2"
+    :default-file-input="fileInput2"
+/><br />
+<p>In addition to <code>$</code>, the handlers are also given <code>m</code>, the <code>RegExpMatchArray</code> from when it was compared to the regex, as
+well as <code>g</code>, the (possibly undefined) set of capture groups, aka <code>m.groups</code>:</p>
 
-            Let's take a look at a more complicated <span class="code-span">lait</span> script. If you want to save your script to a file (helpful for things
-            like syntax highlighting!), you can pass the <span class="code-span">-f</span> flag, for example,
-        </p><br />
-
-        <textarea cols="60" rows="1" disabled>lait -f demo.lait.ts demo_input</textarea><br />
-
-        <LaitPlayground
-            :default-script-input="scriptInput2"
-            :default-file-input="fileInput1"
-        /><br />
-
-        <p>
-            Note that programs of this size are less common. Like <span class="code-span">awk</span>, <span class="code-span">lait</span> programs are meant to
-            be small and integrated into shell operations.
-
-            The first input given to handlers is <span class="code-span">$</span>, the array of "fields" on the line. Unlike
-            <span class="code-span">awk</span>, the array is simply a zero-based array of fields, and there is not a "complete line" entry in
-            <span class="code-span">$</span>. Like <span class="code-span">awk</span>, the default field separator is space, and it can be overridden via the
-            <span class="code-span">FS</span> global:
-        </p><br />
-
-        <LaitPlayground
-            :default-script-input="scriptInput3"
-            :default-file-input="fileInput3"
-        /><br />
-
-        <p>
-            In addition to <span class="code-span">$</span>, the handlers are also given <span class="code-span">m</span>, the <span class="code-span">
-            RegExpMatchArray</span> from when it was compared to the regex, as well as <span class="code-span">g</span>, the (possibly undefined) set of
-            capture groups, aka <span class="code-span">m.groups</span>:
-        </p><br />
-
-        <LaitPlayground
-            :default-script-input="scriptInput4"
-            :default-file-input="fileInput1"
-        /><br />
-
-        <p>
-            <span class="code-span">lait</span> can also accept input from standard in:
-        </p><br />
-        <textarea cols="60" rows="15" disabled>$ ls -al
+<LaitPlayground
+    :default-script-input="scriptInput3"
+    :default-file-input="fileInput3"
+/><br />
+<p><code>lait</code> can also accept input from standard in:</p>
+<pre><code class="language-shell">$ ls -al
 total 14
 drwxr-xr-x 1 user 197609   0 Dec  8 22:01 .
 drwxr-xr-x 1 user 197609   0 Dec  8 21:47 ..
@@ -97,74 +70,72 @@ $ ls -al | lait '/^d|-/;{print($[8], `(${$[4]} bytes)`)}'
 demo.csv (61 bytes)
 demo.lait.ts (699 bytes)
 demo_input (87 bytes)
-        </textarea><br /><br />
+</code></pre>
+<h2>Globals</h2>
+<p>In addition to <code>FS</code>, there is also <code>TRIM_EMPTY</code>, which is <code>true</code> by default as is usually convenient for processing
+space-aligned data like in the <code>ls</code> example. That's less useful when processing CSVs:</p>
 
-        <h2>Globals</h2>
+<LaitPlayground
+    :default-script-input="scriptInput4"
+    :default-file-input="fileInput4"
+/><br />
+<p>Without <code>TRIM_EMPTY=false;</code>, the last line of that would have been:</p>
+<pre><code class="language-shell">Bob Nofunpants 4
+</code></pre>
+<h2>Imports</h2>
+<p>You can import from the Node standard library, as well as any node modules you would expect to be accessible either globally or from a module installed in the working directory's <code>node_modules</code>. Note: This doesn't work in the interactive playground since it is run by the browser. Also note that imports from local files are not yet working.</p>
+<pre><code class="language-shell">$ lait 'import * as _ from &quot;lodash&quot;; print(_.isNumber(12));'
+true
+</code></pre>
+<h2>Installation</h2>
+<p>All you gotta do is</p>
+<pre><code class="language-shell">npm i -g @ajbowen249/lait
+</code></pre>
+<h2>But Why?</h2>
+<p>While <code>awk</code> is a very powerful tool, it can have a few rough edges. Those being:</p>
+<ol>
+<li>Fragmentation - One must always be wary of which implementation they're using, and which builtins are available.</li>
+<li>Regex Syntax - <code>awk</code> has yet another regular expression syntax to remember, and it even varies by vendor.</li>
+<li>Scripting Syntax - Like the regex point, <code>awk</code> using its own scripting language means one must play the, &quot;is <em>this</em>
+how I do x in this language?&quot; game. While <code>TypeScript</code> (and, let's be real, using the type system here will be rare)
+is certainly not universal, it's much more likely someone willing to install an <code>NPM</code> package will be familiar with
+it. Standard <code>awk</code> is also light on language features and built-ins, and having built-in array sort and higher-order
+functions should prove useful in problems typically solved with <code>awk</code>.</li>
+</ol>
 
-        <p>
-            In addition to <span class="code-span">FS</span>, there is also <span class="code-span">TRIM_EMPTY</span>, which is <span class="code-span">true
-            </span> by default as is usually convenient for processing space-aligned data like in the <span class="code-span">ls</span> example. That's less
-            useful when processing CSVs:
-        </p><br />
-
-        <LaitPlayground
-            :default-script-input="scriptInput5"
-            :default-file-input="fileInput5"
-        /><br />
-
-        <p>
-            Without <span class="code-span">TRIM_EMPTY=false;</span>, the last line of that would have been:
-        </p><br />
-        <textarea cols="60" rows="1" disabled>Bob Nofunpants 4</textarea><br /><br />
-
-        <h2>Imports</h2>
-
-        <p>
-            You can import from the Node standard library, as well as any node modules you would expect to be accessible either globally or from a module
-            installed in the working directory's <span class="code-span">node_modules</span>. Note: This doesn't work in the interactive shell since it is run
-            by the browser. Also note that imports from local files are not yet working.
-        </p><br />
-
-        <textarea cols="60" rows="3" disabled>$ lait 'import * as _ from "lodash"; print(_.isNumber(12));'
-true</textarea>
-
-        <h2>Installation</h2>
-
-        <p>
-            All you gotta do is
-        </p><br />
-        <textarea cols="60" rows="1" disabled>npm i -g @ajbowen249/lait</textarea><br /><br />
-
-        <h2>But Why?</h2>
-
-        <p>
-            While <span class="code-span">awk</span> is a very powerful tool, it can have a few rough edges. Those being:
-        </p>
-
-        <ol>
-            <li>Fragmentation - One must always be wary of which implementation they're using, and which builtins are available.</li>
-            <li>Regex Syntax - <span class="code-span">awk</span> has yet another regular expression syntax to remember, and it even varies by vendor.</li>
-            <li>Scripting Syntax - Like the regex point, <span class="code-span">awk</span> using its own scripting language means one must play the, "is <i>
-            this</i> how I do x in this language?" game. While <span class="code-span">TypeScript</span> (and, let's be real, using the type system here will
-            be rare) is certainly not universal, it's much more likely someone willing to install an <span class="code-span">NPM</span> package will be
-            familiar with it. Standard <span class="code-span">awk</span> is also light on language features and built-ins, and having built-in array sort and
-            higher-order functions should prove useful in problems typically solved with <span class="code-span">awk</span>.</li>
-        </ol><br /><br />
     </main>
 </template>
-
 <script setup lang="ts">
 
 import LaitPlayground from '@/components/LaitPlayground.vue';
 import { ref } from 'vue';
-const scriptInput1 = ref('/#\\w{5} \\w+ \\d+/; { print($[2], $[1]) }');
+
+const fileInput0 = ref(`OrderId Item Quantity
+#a2fr5 Socks 16
+#d8j38 Avocado 2
+#8fh39 Shampoo 1
+#qb6ag Candle 3`);
 const fileInput1 = ref(`OrderId Item Quantity
 #a2fr5 Socks 16
 #d8j38 Avocado 2
 #8fh39 Shampoo 1
 #qb6ag Candle 3`);
+const fileInput2 = ref(`Name,Age,ID
+Carol,25,2lf8ah
+Bob,21,j8efy3g
+Jesse,34,j8fhiuad8`);
+const fileInput3 = ref(`OrderId Item Quantity
+#a2fr5 Socks 16
+#d8j38 Avocado 2
+#8fh39 Shampoo 1
+#qb6ag Candle 3`);
+const fileInput4 = ref(`Name,Favorite Film (Optional),Score
+Cathy Smith,A Fistful of Dollars,78
+Paulo Henry MacMasterson III,Finding Nemo,4
+Bob Nofunpants,,4`);
 
-const scriptInput2 = ref(`interface Order {
+const scriptInput0 = ref(`/#\\w{5} \\w+ \\d+/; { print(\$[2], \$[1]) }`);
+const scriptInput1 = ref(`interface Order {
     id: string;
     item: string;
     quantity: number;
@@ -173,20 +144,20 @@ const scriptInput2 = ref(`interface Order {
 const letterOrders: Order[] = [];
 const digitOrders: Order[] = [];
 
-function parseOrder($: string[]) {
+function parseOrder(\$: string[]) {
     return {
-        id: $[0],
-        item: $[1],
-        quantity: parseInt($[2]),
+        id: \$[0],
+        item: \$[1],
+        quantity: parseInt(\$[2]),
     };
 }
 
 /[a-z]\\w{4} \\w+ \\d+/; {
-    letterOrders.push(parseOrder($));
+    letterOrders.push(parseOrder(\$));
 }
 
 /\\d\\w{4} \\w+ \\d+/; {
-    digitOrders.push(parseOrder($));
+    digitOrders.push(parseOrder(\$));
 }
 
 function toTable(order: Order) {
@@ -198,31 +169,9 @@ print('Order ID starts with letter:');
 print(letterOrders.map(toTable).join('\\n'));
 
 print('Order ID starts with digit:');
-print(digitOrders.map(toTable).join('\\n'));`
-);
-
-const scriptInput3 = ref('FS=`,`; { print($[0], `#${$[2]}`); }');
-const fileInput3 = ref(`Name,Age,ID
-Carol,25,2lf8ah
-Bob,21,j8efy3g
-Jesse,34,j8fhiuad8`);
-
-const scriptInput4 = ref('/(?<id>#\\w{5}) (?<name>\\w+) (?<a>\\d+)/; { print(g.a, g.name, m[0]) }');
-
-const scriptInput5 = ref('FS=`,`;TRIM_EMPTY=false; {print($[0], $[1] || `hates movies :(`)}');
-const fileInput5 = ref(`Name,Favorite Film (Optional),Score
-Cathy Smith,A Fistful of Dollars,78
-Paulo Henry MacMasterson III,Finding Nemo,4
-Bob Nofunpants,,4`);
+print(digitOrders.map(toTable).join('\\n'));`);
+const scriptInput2 = ref(`FS=\`,\`; { print(\$[0], \`#\${\$[2]}\`); }`);
+const scriptInput3 = ref(`/(?<id>#\\w{5}) (?<name>\\w+) (?<amnt>\\d+)/; { print(g.amnt, g.name, m[0]) }`);
+const scriptInput4 = ref(`FS=\`,\`;TRIM_EMPTY=false; { print(\$[0], \$[1] || \`does not like movies :(\`)  }`);
 
 </script>
-
-<style scoped>
-.lait-image {
-    width: 300px;
-    display: block;
-    margin: auto;
-    border: 2px solid var(--color-white-mute);
-    border-radius: 20px;
-}
-</style>


### PR DESCRIPTION
The `README.md` and `HomeView.vue` docs files are now generated from a common `docs.md` file with extra markup to handle splitting between the two and integrating interactive examples.